### PR TITLE
Add repository key to _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,6 +5,11 @@ description: The Federal Risk and Authorization Management Program, or FedRAMP, 
 baseurl: /fedramp-gov
 # the base hostname & protocol for your site
 url: "https://fedramp.gov"
+
+# the GitHub name-with-owner, needed for the github-metadata plugin
+# ref: https://github.com/jekyll/github-metadata/blob/master/docs/configuration.md#configuration
+repository: gsa/fedramp-gov
+
 logo: /assets/img/logo-main-fedramp.png
 feature_image: /assets/img/feature-background.jpg
 


### PR DESCRIPTION
ref: https://github.com/GSA/fedramp-gov/issues/53

The `github-pages` plugin uses the `github-metadata` gem to populate some repository-specific information as Jekyll variables. 

Normally, `github-metadata` will fallback to retrieving the repository "name-with-owner" by reading from `git remote origin`. However, for whatever reason, it will not do this if `JEKYLL_ENV` is not `'development'` or `'test'` (ref https://github.com/jekyll/github-metadata/blob/master/lib/jekyll-github-metadata/repository_finder.rb#L67). 

In a recent change to Federalist build container, `JEKYLL_ENV` was set to `'production'`, so `github-metadata` started causing an error during `jekyll build`.

Adding an explicit `repository:` key to `_config.yml` will solve the error.


