### PR TITLE
Adding sitemap plugin 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,5 @@ gem 'jekyll-menus'
 gem "github-pages", group: :jekyll_plugins
 gem 'jekyll-paginate'
 gem 'jekyll-redirect-from'
+gem 'jekyll-sitemap'
+gem 'jekyll-last-modified-at'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,9 @@ GEM
     jekyll-github-metadata (2.9.3)
       jekyll (~> 3.1)
       octokit (~> 4.0, != 4.4.0)
+    jekyll-last-modified-at (1.0.1)
+      jekyll (~> 3.3)
+      posix-spawn (~> 0.3.9)
     jekyll-mentions (1.2.0)
       activesupport (~> 4.0)
       html-pipeline (~> 2.3)
@@ -204,6 +207,7 @@ GEM
       sawyer (~> 0.8.0, >= 0.5.3)
     pathutil (0.16.1)
       forwardable-extended (~> 2.6)
+    posix-spawn (0.3.13)
     public_suffix (2.0.5)
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
@@ -235,9 +239,11 @@ PLATFORMS
 
 DEPENDENCIES
   github-pages
+  jekyll-last-modified-at
   jekyll-menus
   jekyll-paginate
   jekyll-redirect-from
+  jekyll-sitemap
 
 BUNDLED WITH
    1.16.1

--- a/_config.yml
+++ b/_config.yml
@@ -88,6 +88,8 @@ exclude:
 plugins:
   - jekyll-paginate
   - jekyll-redirect-from
+  - jekyll-sitemap
+  - jekyll-last-modified-at
 
 paginate: 5
 paginate_path: "/blog/page:num/"


### PR DESCRIPTION
Using the https://github.com/jekyll/jekyll-sitemap gem to auto generate a sitemap.xml file
Preview of sitemap - https://federalist-proxy.app.cloud.gov/preview/gsa/fedramp-gov/sw-sitemap-generate/sitemap.xml

Search.gov can use this sitemap.xml and ingest this file straight into their index on the backend 🎉 
Once the sitemap is live search.gov can reindex :)

**Screenshot of part of the XML generated**
![screen shot 2018-02-08 at 10 20 57 am](https://user-images.githubusercontent.com/1449852/35980590-1832374c-0cb9-11e8-8060-fd7dfaaaac75.png)

closes #62  