### PR TITLE
Don't index paginated blog links

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -2,4 +2,5 @@
 layout: blog-list
 title: Focus on FedRAMP
 body-class: page-blog
+sitemap: false
 ---


### PR DESCRIPTION
Per search.gov folks recommendation, don't index blog pages.


If you want to remove a specific page from the auto generated sitemap just add `sitemap: false` to that pages front matter.

**Removing these types of links from the sitemap.xml**

```xml
<url>
<loc>https://fedramp.gov/blog/page2/</loc>
</url>
<url>
<loc>https://fedramp.gov/blog/page3/</loc>
</url>
<url>
<loc>https://fedramp.gov/blog/page4/</loc>
</url>
<url>
<loc>https://fedramp.gov/blog/page5/</loc>
</url>
<url>
<loc>https://fedramp.gov/blog/page6/</loc>
</url>
<url>
<loc>https://fedramp.gov/blog/page7/</loc>
</url>
<url>
```