### PR TITLE
Search encoding

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -78,8 +78,11 @@ function searchAndDisplayResults(query) {
         .html();
     });
 
+    // Check for results
+    const content = results.length ? results.join('') : '<p>No results found.</p>';
+
     // add results to page
-    $('#results').append(results.join(''));
+    $('#results').append(content);
   });
 }
 

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -39,8 +39,16 @@ function getUrlParams(paramStr) {
 
   return hashes.reduce((params, hash) => {
     const [key, val] = hash.split('=');
-    return Object.assign(params, { [key]: decodeURIComponent(val) });
+    // Decode the value, replacing + with %20 (space characters)
+    return Object.assign(params, { [key]: decodeURIComponent((val || '').replace(/\+/g, '%20')) });
   }, {});
+}
+
+function highlight(text) {
+  // search.gov returns highlight markers that need to be replaced for HTML tags
+  return (text || '')
+    .replace(/\ue000/g, '<strong>')
+    .replace(/\ue001/g, '</strong>');
 }
 
 function searchAndDisplayResults(query) {
@@ -48,11 +56,27 @@ function searchAndDisplayResults(query) {
   $('#results').empty();
 
   // attempt search
-  $.getJSON(`${SEARCH_BASE}&query=${query}`, json => {
+  $.getJSON(SEARCH_BASE, { query }, json => {
     // format each entry as li element
-    const results = json.web.results.map(
-      d => `<li><h2><a href="${d.url}">${d.title}</a></h2><p>${d.snippet}</p></li>`
-    );
+    const results = json.web.results.map((result) => {
+      // Use jQuery to encode the result, then replace the highlight markers.
+      const title = highlight($('<i>').text(result.title).html());
+      const snippet = highlight($('<i>').text(result.snippet).html());
+
+      const $header = $('<h2>')
+        .append(
+          $('<a>')
+            .attr('href', result.url)
+            .html(title)
+        );
+
+      const $snippet = $('<p>').html(snippet);
+
+      return $('<li>')
+        .append($header)
+        .append($snippet)
+        .html();
+    });
 
     // add results to page
     $('#results').append(results.join(''));


### PR DESCRIPTION
This should be merged to the demo branch, correct?

Fixes issue with unicode highlight markers rendering as empty boxes mentioned in #73. I've also included a few other fixes:

- Replace search.gov highlight markers with HTML tags (and avoid rendering them
as unknown characters)
- Encode/decode search queries properly (fixes searching with `&` in query)
- Decode search queries with spaces properly (decode `+` as a space)
- Use jQuery to encode the text from search API results.
- Show a message when there are no search results.