### PR TITLE
Improve print styles for header and footer

### DIFF
--- a/_sass/_header.scss
+++ b/_sass/_header.scss
@@ -251,6 +251,12 @@ nav.usa-nav {
 /** PRINT FRIENDLY **/
 @media print {
 
+.card-image,
+.hero-unit {
+	min-height: auto;
+}
+
+
 .panel {
 	display:block;
 }
@@ -260,7 +266,10 @@ nav.usa-nav {
 .usa-banner-button,
 .usa-menu-btn,
 .newsletter-footer,
-.footer-social {
+.footer-social,
+.post-container,
+.usa-footer-logo,
+.usa-footer {
 	display: none;
 }
 
@@ -292,15 +301,29 @@ section#fedramp-mission .inner{
 	}
 }
 
+.banner.tagline h2,
+.banner.tagline p {
+	color: #212121 !important;
+}
+
+.hero-content  {
+	h1, p {
+	color: #212121 !important;
+}
+}
+
 section#pre-auth,
 section#during-auth,
 section#post-auth,
 section#support,
-.usa-section {
+.usa-section,
+.home .hero-unit,
+.hero-content {
 	padding: 0;
 }
 
-.page-blog .usa-width-one-whole {
+.page-blog .usa-width-one-whole,
+.card {
 	padding: 0;
 	margin: 0;
 }

--- a/_sass/_header.scss
+++ b/_sass/_header.scss
@@ -250,47 +250,74 @@ nav.usa-nav {
 
 /** PRINT FRIENDLY **/
 @media print {
-	
-	html, body {
-            margin: 0;
-            padding: 0;
-            background: #FFF; 
-            font-size: 9.5pt;
-          }
-          .container, .container div {
-            width: 100%;
-            margin: 0;
-            padding: 0;
-          }
-	/*
-          .template { 
-		  overflow: hidden;
-	   }
-	*/
 
-          img { 
-		  width: 100%; 
-	  }
+.panel {
+	display:block;
+}
 
-	
-	#navigation, #subnavigation{
+.blog-sidebar,
+.search-feature,
+.usa-banner-button,
+.usa-menu-btn,
+.newsletter-footer,
+.footer-social {
 	display: none;
+}
+
+div.usa-nav-container {
+	padding: 0;
+	height: auto;
+}
+
+body .page-banner {
+	padding-bottom: 0 !important;
+	padding-top: 0 !important;
+}
+
+	body,
+	html {
+		margin: 0;
+		padding: 0;
+		background: #FFF;
+		font-size: 9.5pt;
+		color: #212121 !important;
+	}
+
+	.container,
+	.container div {
+		width: 100%;
+		margin: 0;
+		padding: 0;
+	}
+
+	img {
+		width: 100%;
+	}
+
+	#navigation,
+	#subnavigation {
+		display: none;
 	}
 
 	h1 {
-	font-size: 24pt;
+		font-size: 24pt;
 	}
-	h2 {
-	font-size: 18pt;
-	}
-	h3 {
-	font-size: 14pt;
-	}
-	p, ul, ol, dl {
-	/* paragraphs, unordered, ordered, and definition lists */
-	font-size: 12pt;
-	}
-    /* Print CSS rules go here */
-    /* Note: You need a separate @media screen group for other rules */
-}
 
+	h2 {
+		font-size: 18pt;
+	}
+
+	h3 {
+		font-size: 14pt;
+	}
+
+	dl,
+	ol,
+	p,
+	ul {
+		/* paragraphs, unordered, ordered, and definition lists */
+		font-size: 12pt;
+	}
+	/* Print CSS rules go here */
+	/* Note: You need a separate @media screen group for other rules */
+}

--- a/_sass/_header.scss
+++ b/_sass/_header.scss
@@ -272,6 +272,37 @@ div.usa-nav-container {
 body .page-banner {
 	padding-bottom: 0 !important;
 	padding-top: 0 !important;
+	h1 {
+		color: #212121 !important;
+	}
+}
+
+section#fedramp-mission .inner{
+	h2,
+	ul li {
+		color: #212121 !important;
+	}
+}
+
+.about-us section.about-auth .inner {
+	color: #212121 !important;
+	h2,
+	p, a {
+		color: #212121 !important;
+	}
+}
+
+section#pre-auth,
+section#during-auth,
+section#post-auth,
+section#support,
+.usa-section {
+	padding: 0;
+}
+
+.page-blog .usa-width-one-whole {
+	padding: 0;
+	margin: 0;
 }
 
 	body,


### PR DESCRIPTION
Preview 
https://federalist-proxy.app.cloud.gov/preview/gsa/fedramp-gov/sw-print-styles/



- [x] clean up the header and footer print styles
- [x] hide the blog-sidebar when printing
- [x] homepage
- [x] spacing after headers
- [x] text color (sometimes the text is grey- not good for readability)
---

Regarding images - In general it is OK to not print images if they are not needed to understand the context (read: _just decorative_) For example, images on **jab authorization** support the content as they show diagrams while the icons next to the headers on the **federal agencies** page can be left off without consequence 

Things to address still 

- [ ] images on meet the team should be foreground images if we want them to print
- [ ] images on blog pages should be smaller