### PR TITLE
fix search on home page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,6 +15,10 @@ feature_image: /assets/img/feature-background.jpg
 logo: /assets/img/logo-main-fedramp.png
 feature_image: /assets/img/feature-background.jpg
 
+
+marketplaceurl: https://marketplace.fedramp.gov/
+
+
 colors:
   background: '#ffffff'
   link:

--- a/_layouts/search-results.html
+++ b/_layouts/search-results.html
@@ -2,16 +2,9 @@
 layout: base
 ---
 
-<div class="page-banner">
-<h1> {{ page.title }}</h1>
-</div>
-<div class="usa-grid usa-section usa-content">
-<div class="usa-width-three-fourths usa-content">
-{% if page.image %}
-<img src="{{ page.image | prepend: site.baseurl }}">
-{% endif %}
-{{ content }}
-<ul id="results" class="usa-unstyled-list"></ul>
-</div>
-</div>
-</div>
+<script>
+  var baseurl = "{{ site.baseurl }}";
+  var urlParams = new URLSearchParams(window.location.search);
+  var search_term = urlParams.get('search');
+  window.location = '{{site.marketplaceurl}}#/search/' + search_term;
+</script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}


### PR DESCRIPTION
searching on the primary domain has been removed from federalist homepage. Search is now part of marketplace. Currently, if you search in the federalist page, it returns nothing. Instead,  search terms should redirect to working search page. This patch does that.

Alternative approach: change the <form> code to search the proper domain, but the param structure in marketplace means this would be a more complicated fix. 