### PR TITLE
Make "FedRAMP At a Glance" numbers dynamic

### DIFF
--- a/_includes/fedramp-summary.html
+++ b/_includes/fedramp-summary.html
@@ -26,30 +26,3 @@
     </li>
   </ul>
 </section>
-
-<script type="text/javascript">
-  fetch('https://raw.githubusercontent.com/18F/fedramp-data/master/data/data.json')
-  .then(function(response) {
-    return response.json();
-  }).then(function(json) {
-    var providers = json.data.Providers;
-    if (!providers) return;
-
-    var totalAuthorized = 0;
-    var totalInProcess = 0;
-    var totalReady = 0;
-
-    for (i = 0; i < providers.length; i++) {
-      if (providers[i].Designation === 'Compliant') totalAuthorized += 1;
-      if (providers[i].Designation === 'In Process') totalInProcess += 1;
-      if (providers[i].Designation === 'FedRAMP Ready') totalReady += 1;
-    }
-
-    document.getElementById("totalAuthorized").textContent = totalAuthorized;
-    document.getElementById("totalInProcess").textContent = totalInProcess;
-    document.getElementById("totalReady").textContent = totalReady;
-
-  }).catch(function(ex) {
-    console.log('parsing totals failed', ex)
-  })
-</script>

--- a/_includes/fedramp-summary.html
+++ b/_includes/fedramp-summary.html
@@ -1,0 +1,55 @@
+<section class="fedramp-glance">
+  <h2 class="text-center home-glance padding-bottom-2" style="padding-bottom: 2rem;">FedRAMP at a Glance</h2>
+  <ul class="glance-numbers">
+    <li>
+    <img src="{{site.baseurl}}/assets/img/glance-ready.svg" alt="">
+    <span>
+    <p>Ready</p>
+    <p class="number" id="totalReady">33</p>
+    </span>
+    </li>
+
+    <li>
+      <img src="{{site.baseurl}}/assets/img/glance-process.svg" alt="">
+    <span>
+    <p>In Process</p>
+    <p class="number" id="totalInProcess">53</p>
+    </span>
+    </li>
+
+    <li>
+      <img src="{{site.baseurl}}/assets/img/glance-authorized.svg" alt="">
+    <span>
+    <p>Authorized</p>
+    <p class="number" id="totalAuthorized">211</p>
+    </span>
+    </li>
+  </ul>
+</section>
+
+<script type="text/javascript">
+  fetch('https://raw.githubusercontent.com/18F/fedramp-data/master/data/data.json')
+  .then(function(response) {
+    return response.json();
+  }).then(function(json) {
+    var providers = json.data.Providers;
+    if (!providers) return;
+
+    var totalAuthorized = 0;
+    var totalInProcess = 0;
+    var totalReady = 0;
+
+    for (i = 0; i < providers.length; i++) {
+      if (providers[i].Designation === 'Compliant') totalAuthorized += 1;
+      if (providers[i].Designation === 'In Process') totalInProcess += 1;
+      if (providers[i].Designation === 'FedRAMP Ready') totalReady += 1;
+    }
+
+    document.getElementById("totalAuthorized").textContent = totalAuthorized;
+    document.getElementById("totalInProcess").textContent = totalInProcess;
+    document.getElementById("totalReady").textContent = totalReady;
+
+  }).catch(function(ex) {
+    console.log('parsing totals failed', ex)
+  })
+</script>

--- a/_includes/javascript.html
+++ b/_includes/javascript.html
@@ -5,6 +5,7 @@
 <script src="{{ '/assets/js/functions.min.js' | prepend: site.baseurl  }}" type="text/javascript"></script>
 <script src="{{ '/assets/js/tabs.min.js' | prepend: site.baseurl  }}" type="text/javascript" defer></script>
 <script src="{{ '/assets/js/inpageNav.min.js' | prepend: site.baseurl  }}" type="text/javascript" defer></script>
+<script src="{{ '/assets/js/fedramp-totals.js' | prepend: site.baseurl  }}" type="text/javascript"></script>
 
 
 

--- a/_layouts/home-new.html
+++ b/_layouts/home-new.html
@@ -126,33 +126,6 @@ layout: base
 	</div>	
 </section>
 
-<section class="fedramp-glance">
-<h2 class="text-center home-glance padding-bottom-2" style="padding-bottom: 2rem;">FedRAMP at a Glance</h2>
-<ul class="glance-numbers">
-	<li>
-	<img src="{{site.baseurl}}/assets/img/glance-ready.svg" alt="">
-	<span>
-	<p>Ready</p>
-	<p class="number">23</p>
-	</span>
-	</li>
-	
-	<li>
-		<img src="{{site.baseurl}}/assets/img/glance-process.svg" alt="">
-	<span>
-	<p>In Process</p>
-	<p class="number">49</p>
-	</span>
-	</li>
-	
-	<li>
-		<img src="{{site.baseurl}}/assets/img/glance-authorized.svg" alt="">
-	<span>
-	<p>Authorized</p>
-	<p class="number">199</p>
-	</span>
-	</li>
-</ul>
-</section>
+{% include fedramp-summary.html %}
 
 <a id="topButton"></a>

--- a/assets/js/fedramp-totals.js
+++ b/assets/js/fedramp-totals.js
@@ -1,0 +1,41 @@
+/**
+Fetch FedRAMP total numbers from Auth Log JSON
+See _includes/fedramp-summary.html for element id's
+**/
+
+$(document).ready(function(){
+    var authEl      = document.getElementById("totalAuthorized");
+    var inProcessEl = document.getElementById("totalInProcess");
+    var readyEl     = document.getElementById("totalReady");
+    if (!authEl || !inProcessEl || !readyEl) return;
+
+    var onSuccess = function(json, elements) {
+        if (!json.data) return;
+
+        var providers = json.data.Providers;
+        var totalAuthorized = 0;
+        var totalInProcess = 0;
+        var totalReady = 0;
+
+        for (i = 0; i < providers.length; i++) {
+          if (providers[i].Designation === 'Compliant') totalAuthorized += 1;
+          if (providers[i].Designation === 'In Process') totalInProcess += 1;
+          if (providers[i].Designation === 'FedRAMP Ready') totalReady += 1;
+        }
+
+        elements.authEl.textContent = totalAuthorized;
+        elements.inProcessEl.textContent = totalInProcess;
+        elements.readyEl.textContent = totalReady;
+    }
+
+    $.ajax({
+      url: 'https://raw.githubusercontent.com/18F/fedramp-data/master/data/data.json',
+      dataType: 'json',
+      success: function ( json ) {
+        onSuccess(json, {
+            authEl:      authEl,
+            inProcessEl: inProcessEl,
+            readyEl:     readyEl
+        }) }
+    });
+});


### PR DESCRIPTION
Data is fetched from [fedramp-data](https://github.com/18F/fedramp-data/blob/master/data/data.json) repo, tallied, then the tallies replace static numbers.

Fetching is done through jQuery, which should be IE browser compatible. 

Kept static numbers realistic, in case fetching for some reason fails. 


