### PR TITLE
Adding additional redirects for old pages 

### DIFF
--- a/pages/redirect-about.md
+++ b/pages/redirect-about.md
@@ -1,0 +1,7 @@
+---
+layout: full-width
+title: Program Overview
+tab-title: About FedRAMP
+permalink: /about/
+redirect_to: /program-basics/
+---

--- a/pages/redirect-documents.md
+++ b/pages/redirect-documents.md
@@ -1,0 +1,7 @@
+---
+layout: full-width
+title: FedRAMP Documents
+tab-title: FedRAMP Documents
+permalink: /documents/
+redirect_to: /documents-templates/
+---

--- a/pages/redirect-templates.md
+++ b/pages/redirect-templates.md
@@ -1,0 +1,7 @@
+---
+layout: full-width
+title: FedRAMP Templates
+tab-title: FedRAMP Templates
+permalink: /templates/
+redirect_to: /documents-templates/
+---

--- a/pages/redirect-tips-cues.md
+++ b/pages/redirect-tips-cues.md
@@ -3,5 +3,5 @@ layout: full-width
 title: FedRAMP Tips and Cues
 tab-title: Conducting Continuous Monitoring (ConMon)
 permalink: /tips-cues/
-redirect_to: /blog/
+redirect_to: /faqs/
 ---

--- a/pages/redirect-tips-cues.md
+++ b/pages/redirect-tips-cues.md
@@ -1,0 +1,7 @@
+---
+layout: full-width
+title: FedRAMP Tips and Cues
+tab-title: Conducting Continuous Monitoring (ConMon)
+permalink: /tips-cues/
+redirect_to: /blog
+---

--- a/pages/redirect-tips-cues.md
+++ b/pages/redirect-tips-cues.md
@@ -3,5 +3,5 @@ layout: full-width
 title: FedRAMP Tips and Cues
 tab-title: Conducting Continuous Monitoring (ConMon)
 permalink: /tips-cues/
-redirect_to: /blog
+redirect_to: /blog/
 ---


### PR DESCRIPTION
Adding the following redirects:

[demo.fedramp.gov/documents/](url)
[demo.fedramp.gov/templates/](url)
[demo.fedramp.gov/tips-cues/](url)
[demo.fedramp.go/about/](url)