### PR TITLE
resolved errors to Blog: Update to FedRAMP Templates JUNE 22 | 2016

### DIFF
--- a/_posts/2016-06-22-update-to-fedramp-templates.md
+++ b/_posts/2016-06-22-update-to-fedramp-templates.md
@@ -2,8 +2,10 @@
 title: Update to FedRAMP Templates
 layout: blog-list
 permalink: /update-to-fedramp-templates/
-image: /assets/img/blog-images/FRblog_resource-new.png
 body-class: page-blog
+image: /assets/img/blog-images/FRblog_resource-new.png
+author: FedRAMP
+layout: blog-page
 ---
 On Monday, June 27th FedRAMP will be releasing updates to our templates to add some “ease of use” features as well as ensure all of the templates reflect the different authorization levels (low, moderate, high) that CSPs can pursue through FedRAMP.
 


### PR DESCRIPTION
Post did not have an image, in effort to add it, the post was removed from the entry template