### PR TITLE
Simpler and no trademark symbol

### DIFF
--- a/_layouts/team-list.html
+++ b/_layouts/team-list.html
@@ -6,7 +6,7 @@ layout: full-width
 	<div class="grid-container">
 		<div class="grid-row padding-top-2">
 			<div class="desktop:grid-col-12">
-				<h2 class="">The FedRAMP<sup>®</sup> Program Management Office</h2>
+				<h2 class="">The FedRAMP Team</h2>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
We don't need the (R) here, and "team" is more natural for what this page is.