### PR TITLE
Launch help center

### DIFF
--- a/_data/navbar.yml
+++ b/_data/navbar.yml
@@ -83,7 +83,6 @@ assigned:
         - 
             text: Help Center
             is_external: https://marketplace.fedramp.gov
-            permalink: /help-center/
             show_in_menu: true
             show_in_footer: false            
         - 

--- a/_data/navbar.yml
+++ b/_data/navbar.yml
@@ -87,12 +87,6 @@ assigned:
             show_in_menu: true
             show_in_footer: false
 
-        -
-            text: FAQs
-            href: pages/faqs.md
-            permalink: /faqs/
-            show_in_menu: true
-            show_in_footer: false 
         - 
             text: Baselines
             href: pages/baselines.md
@@ -113,12 +107,7 @@ assigned:
             permalink: /et-framework/
             show_in_menu: true
             show_in_footer: false    
-        - 
-            text: DMARC
-            href: pages/dmarc.md
-            permalink: /dmarc/
-            show_in_menu: true
-            show_in_footer: false 
+            
         - 
             text: Cryptographic Module
             href: cryptographic-module.md

--- a/_data/navbar.yml
+++ b/_data/navbar.yml
@@ -82,7 +82,7 @@ assigned:
             show_in_footer: false
         - 
             text: Help Center
-            is_external: https://marketplace.fedramp.gov
+            is_external: https://help.fedramp.gov/hc/en-us
             show_in_menu: true
             show_in_footer: false            
         - 

--- a/_data/navbar.yml
+++ b/_data/navbar.yml
@@ -81,6 +81,12 @@ assigned:
             show_in_menu: true
             show_in_footer: false
         - 
+            text: Help Center
+            is_external: https://marketplace.fedramp.gov
+            permalink: /help-center/
+            show_in_menu: true
+            show_in_footer: false            
+        - 
             text: Training
             href: pages/training.md
             permalink: /training/

--- a/_layouts/dmarc.html
+++ b/_layouts/dmarc.html
@@ -53,7 +53,7 @@ layout: full-width
       <div class="full-col tablet:grid-col-9 tablet:grid-offset-3 nav-main-section">
 
 		<div class="intro-text">
-			 <h2>Please note that this content has been relocated to the FedRAMP <a href="https://www.UPDATE WITH CORRECT URL" target="_blank">Help Center</a>. For the most current version, please visit the <a href="https://www.UPDATE WITH CORRECT URL" target="_blank">Help Center</a>.</h2>
+			 <h2>Please note that this content has been relocated to the FedRAMP <a href="https://help.fedramp.gov/hc/en-us" target="_blank">Help Center</a>. For the most current version, please visit the <a href="https://help.fedramp.gov/hc/en-us" target="_blank">Help Center</a>.</h2>
 			<p><strong>Author:</strong> FedRAMP Knowledge Base</p>
 			<p><strong>Intended Audience:</strong> CSP technical teams, 3PAOs, Agency Reviewers</p>
 			<p><strong>Published:</strong> July 2024</p>

--- a/_layouts/dmarc.html
+++ b/_layouts/dmarc.html
@@ -53,6 +53,7 @@ layout: full-width
       <div class="full-col tablet:grid-col-9 tablet:grid-offset-3 nav-main-section">
 
 		<div class="intro-text">
+			 <h2>Please note that this content has been relocated to the FedRAMP <a href="https://www.UPDATE WITH CORRECT URL" target="_blank">Help Center</a>. For the most current version, please visit the <a href="https://www.UPDATE WITH CORRECT URL" target="_blank">Help Center</a>.</h2>
 			<p><strong>Author:</strong> FedRAMP Knowledge Base</p>
 			<p><strong>Intended Audience:</strong> CSP technical teams, 3PAOs, Agency Reviewers</p>
 			<p><strong>Published:</strong> July 2024</p>

--- a/_layouts/faqs.html
+++ b/_layouts/faqs.html
@@ -81,7 +81,8 @@ layout: full-width
           
           <!-- General -------------------------------->
           
-          <h3 id="faq-general" class="padding-top-2">General</h3>
+          <h2>Please note that this content has been relocated to the FedRAMP Help Center. For the most recent version, please visit the Help Center.</h2>
+	  <h3 id="faq-general" class="padding-top-2">General</h3>
           <h4 class="usa-accordion__heading">
             <button class="usa-accordion__button"
 						aria-expanded="false"

--- a/_layouts/faqs.html
+++ b/_layouts/faqs.html
@@ -81,7 +81,7 @@ layout: full-width
           
           <!-- General -------------------------------->
           
-          <h2>Please note that this content has been relocated to the FedRAMP Help Center. For the most recent version, please visit the Help Center.</h2>
+          <h2>Please note that this content has been relocated to the FedRAMP <a href="https://www.UPDATE WITH CORRECT URL" target="_blank">Help Center</a>. For the most current version, please visit the <a href="https://www.UPDATE WITH CORRECT URL" target="_blank">Help Center</a>.</h2>
 	  <h3 id="faq-general" class="padding-top-2">General</h3>
           <h4 class="usa-accordion__heading">
             <button class="usa-accordion__button"

--- a/_layouts/faqs.html
+++ b/_layouts/faqs.html
@@ -81,7 +81,7 @@ layout: full-width
           
           <!-- General -------------------------------->
           
-          <h2>Please note that this content has been relocated to the FedRAMP <a href="https://www.UPDATE WITH CORRECT URL" target="_blank">Help Center</a>. For the most current version, please visit the <a href="https://www.UPDATE WITH CORRECT URL" target="_blank">Help Center</a>.</h2>
+          <h2>Please note that this content has been relocated to the FedRAMP <a href="https://help.fedramp.gov/hc/en-us" target="_blank">Help Center</a>. For the most current version, please visit the <a href="https://help.fedramp.gov/hc/en-us" target="_blank">Help Center</a>.</h2>
 	  <h3 id="faq-general" class="padding-top-2">General</h3>
           <h4 class="usa-accordion__heading">
             <button class="usa-accordion__button"


### PR DESCRIPTION
- Adding "Help Center" to the "Resources" top nav
- Removing "FAQs" from the "Resources" top nav
- Removing "DMARC" from the "Resources" top nav
- [Adding language to the FAQ page](https://federalist-c2ec0652-d2b5-4b0c-9b83-ef92c9ce7b06.sites.pages.cloud.gov/preview/gsa/fedramp-gov/launch-help-center/faqs/) to direct users to the help center for the most current information without breaking the link
- [Adding language to the DMARC page](https://federalist-c2ec0652-d2b5-4b0c-9b83-ef92c9ce7b06.sites.pages.cloud.gov/preview/gsa/fedramp-gov/launch-help-center/dmarc/) to direct users to the help center for the most current information without breaking the link